### PR TITLE
Fix main.go template

### DIFF
--- a/main.tmpl.go
+++ b/main.tmpl.go
@@ -35,7 +35,7 @@ func main() {
 		Frameless:         false,
 		StartHidden:       false,
 		HideWindowOnClose: false,
-		RGBA:              &options.RGBA{R: 255, G: 255, B: 255, A: 255},
+		BackgroundColour:  &options.RGBA{R: 255, G: 255, B: 255, A: 255},
 		Assets:            assets,
 		Menu:              nil,
 		Logger:            nil,


### PR DESCRIPTION
Fix for https://github.com/benjamin-thomas/wails-elm-template/issues/2

The `RGBA` field was renamed to `BackgroundColour`